### PR TITLE
Add resolved species annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ The geoname annotator uses the geonames.org dataset to resolve mentions of geona
 A classifier is used to disambiguate geonames and rule out false positives.
 
 To use the geoname annotator run the following command to import geonames.org
-data into an embedded sqlite3 database:
+data into epitator's embedded sqlite3 database:
+
+You should review the geonames license before using this data.
 
 ```
-python -m annotator.sqlite_import_geonames
+python -m epitator.importers.import_geonames
 ```
 
 #### Usage
@@ -37,14 +39,18 @@ geoname['longitude']
 
 ### Resolved Keyword Annotator
 
-The resolved keyword annotator uses synonyms from the disease ontology to 
-resolve mentions of diseases to doid uris.
+The resolved keyword annotator uses an sqlite database of entities to resolve
+mentions of multiple synonyms for an entity to a single id.
+This project includes scripts for importing diseases and animal species into
+that database. The following commands cab be used to invoke them:
 
-To use the geoname annotator run the following command to import the disease ontology
-data into an embedded sqlite3 database:
+The scripts import data from the [Disease Ontology](http://disease-ontology.org/) and [ITIS](https://www.itis.gov/).
+You should review their licenses and terms of use before using this data.
+Currently the Disease Ontology is under public domain and ITIS requests citation.
 
 ```
-python -m annotator.sqlite_import_disease_ontology
+python -m epitator.importers.import_species
+python -m epitator.importers.import_disease_ontology
 ```
 
 #### Usage

--- a/epitator/annotator.py
+++ b/epitator/annotator.py
@@ -153,16 +153,19 @@ class AnnoTier(object):
         """Get all spans which overlap a position or range"""
         if not end:
             end = start + 1
-        return [span for span in self.spans if len(set(range(span.start, span.end)).
-                                       intersection(list(range(start, end)))) > 0]
+        return [span for span in self.spans
+                if len(set(range(span.start, span.end)
+                          ).intersection(list(range(start, end)))) > 0]
 
     def spans_in(self, start, end):
         """Get all spans which are contained in a range"""
-        return [span for span in self.spans if span.start >= start and span.end <= end]
+        return [span for span in self.spans
+                if span.start >= start and span.end <= end]
 
     def spans_at(self, start, end):
         """Get all spans with certain start and end positions"""
-        return [span for span in self.spans if start == span.start and end == span.end]
+        return [span for span in self.spans
+                if start == span.start and end == span.end]
 
     def spans_over_span(self, span):
         """Get all spans which overlap another span"""

--- a/epitator/count_annotator.py
+++ b/epitator/count_annotator.py
@@ -104,7 +104,7 @@ class CountAnnotator(Annotator):
                 counts.append(MatchSpan(ne_span, 'count'))
             elif ne_span.label == 'DATE' and is_valid_count(ne_span.text):
                 # Sometimes counts like 1500 are parsed as as the year component
-                # of dates. This tries to catched that mistake when the year
+                # of dates. This tries to catch that mistake when the year
                 # is long enough ago that it is unlikely to be a date.
                 date_as_number = utils.parse_spelled_number(ne_span.text)
                 if date_as_number and date_as_number < 1900:

--- a/epitator/database_interface.py
+++ b/epitator/database_interface.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+from .get_database_connection import get_database_connection
+
+class DatabaseInterface(object):
+    """
+    This interface provides utility methods for the embedded EpiTator database.
+    """
+    def __init__(self):
+        self.db_connection = get_database_connection()
+        def dict_factory(cursor, row):
+            d = {}
+            for idx, col in enumerate(cursor.description):
+                d[col[0]] = row[idx]
+            return d
+        self.db_connection.row_factory = dict_factory
+
+    def lookup_synonym(self, synonym, entity_type):
+        cursor = self.db_connection.cursor()
+        return cursor.execute('''
+        SELECT id, label, synonym, max(weight) AS weight
+        FROM synonyms
+        JOIN entities ON synonyms.entity_id=entities.id
+        WHERE synonym LIKE ? AND entities.type=?
+        GROUP BY entity_id
+        ORDER BY weight DESC, length(synonym) ASC
+        LIMIT 20
+        ''', ['%' + synonym + '%', entity_type])
+
+    def get_entity(self, entity_id):
+        cursor = self.db_connection.cursor()
+        return next(cursor.execute('''
+        SELECT *
+        FROM entities
+        WHERE id = ?
+        ''', [entity_id]), None)

--- a/epitator/date_annotator.py
+++ b/epitator/date_annotator.py
@@ -23,7 +23,7 @@ class DateSpan(AnnoSpan):
         self.start = base_span.start
         self.end = base_span.end
         self.doc = base_span.doc
-        self.label = base_span.label
+        self.label = base_span.doc.text[base_span.start:base_span.end]
         self.datetime_range = datetime_range
 
     def to_dict(self):
@@ -91,11 +91,11 @@ class DateAnnotator(Annotator):
         grouped_date_spans = []
         for date_group in adjacent_date_spans:
             date_group_spans = list(date_group.iterate_leaf_base_spans())
-            if any(strict_parser.get_date_data(span.text)['date_obj'] == None
+            if any(strict_parser.get_date_data(span.text)['date_obj'] is None
                    for span in date_group_spans):
                 extended_span = date_group_spans[0].extended_through(
                     date_group_spans[-1])
-                if date_to_datetime_range(extended_span.text) != None:
+                if date_to_datetime_range(extended_span.text) is not None:
                     grouped_date_spans.append(extended_span)
         # Find date ranges by looking for joiner words between dates.
         date_range_spans = ra.follows([
@@ -128,7 +128,7 @@ class DateAnnotator(Annotator):
                             '-'.join(hyphenated_components[3:])]
             if len(range_components) == 1:
                 datetime_range = date_to_datetime_range(range_components[0])
-                if datetime_range == None:
+                if datetime_range is None:
                     continue
             elif len(range_components) == 2:
                 # March 3 to November 2 1984

--- a/epitator/get_database_connection.py
+++ b/epitator/get_database_connection.py
@@ -2,19 +2,51 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os
 import sqlite3
+
+
 if os.environ.get('ANNOTATOR_DB_PATH'):
     ANNOTATOR_DB_PATH = os.environ.get('ANNOTATOR_DB_PATH')
 else:
     ANNOTATOR_DB_PATH = os.path.expanduser("~") + '/.epitator.sqlitedb'
-
 
 def get_database_connection(create_database=False):
     databse_exists = os.path.exists(ANNOTATOR_DB_PATH)
     if databse_exists or create_database:
         if not databse_exists:
             print("Creating database at:", ANNOTATOR_DB_PATH)
-        return sqlite3.connect(ANNOTATOR_DB_PATH)
+        connection = sqlite3.connect(ANNOTATOR_DB_PATH)
+        cur = connection.cursor()
+        cur.execute("PRAGMA foreign_keys = ON")
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS metadata (
+            property TEXT PRIMARY KEY ASC, value TEXT
+        )""")
+        if not databse_exists:
+            # Initialize the database
+            cur.execute("""
+            CREATE TABLE entities (
+                id TEXT PRIMARY KEY, label TEXT, type TEXT, source TEXT
+            )""")
+            cur.execute("""
+            CREATE TABLE synonyms (
+                synonym TEXT,
+                entity_id TEXT REFERENCES entities(id),
+                weight INTEGER
+            )""")
+            cur.execute('''
+            CREATE INDEX synonym_index ON synonyms (synonym);
+            ''')
+            cur.execute("INSERT INTO metadata VALUES ('dbversion', '0.0.0')")
+            connection.commit()
+        db_version = next(cur.execute("""
+        SELECT value AS version FROM metadata WHERE property = 'dbversion'
+        """), None)
+        if not db_version or db_version[0] != "0.0.0":
+            raise Exception("The database at " + ANNOTATOR_DB_PATH +
+                            " has a version that is not compatible by this version of EpiTator.\n"
+                            "You will need to rerun the data import scripts.")
+        return connection
     else:
         raise Exception("There is no EpiTator database at: " + ANNOTATOR_DB_PATH +
-                        "\nRun `python -m epitator.sqlite_import_geonames` to create a new database"
+                        "\nRun `python -m epitator.sqlite_import_all` to create a new database"
                         "\nor set ANNOTATOR_DB_PATH to use a database at a different location.")

--- a/epitator/importers/import_all.py
+++ b/epitator/importers/import_all.py
@@ -1,0 +1,22 @@
+"""
+Script for importing species names from ITIS (https://www.itis.gov/)
+into the sqlite synonym table so they can be resolved by the resolved keyword
+annotator.
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+from .import_disease_ontology import import_disease_ontology
+from .import_species import import_species
+from .import_geonames import import_geonames
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--drop-previous", dest='drop_previous', action='store_true')
+    parser.set_defaults(drop_previous=False)
+    args = parser.parse_args()
+    import_disease_ontology(args.drop_previous)
+    import_species(args.drop_previous)
+    import_geonames(args.drop_previous)

--- a/epitator/importers/import_species.py
+++ b/epitator/importers/import_species.py
@@ -1,0 +1,122 @@
+"""
+Script for importing species names from ITIS (https://www.itis.gov/)
+into the sqlite synonym table so they can be resolved by the resolved keyword
+annotator.
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+import sqlite3
+from StringIO import StringIO
+from zipfile import ZipFile
+from urllib import urlopen
+from tempfile import NamedTemporaryFile
+from ..get_database_connection import get_database_connection
+from ..utils import batched
+
+
+ITIS_URL = "https://www.itis.gov/downloads/itisSqlite.zip"
+
+# The data model for the itis database is available here:
+# https://www.itis.gov/pdf/ITIS_ConceptualModelEntityDefinition.pdf
+def download_itis_database():
+    print("Downloading ITIS data from: " + ITIS_URL)
+    url = urlopen(ITIS_URL)
+    zipfile = ZipFile(StringIO(url.read()))
+    print("Download complete")
+    with NamedTemporaryFile() as named_temp_file:
+        itis_version = zipfile.filelist[0].filename.split('/')[0]
+        for f in zipfile.filelist:
+            if f.filename.endswith('.sqlite'):
+                with zipfile.open(f) as database_file:
+                    named_temp_file.write(database_file.read())
+                    named_temp_file.flush()
+                    break
+        return sqlite3.connect(named_temp_file.name), itis_version
+
+
+def import_species(drop_previous=False):
+    connection = get_database_connection(create_database=True)
+    cur = connection.cursor()
+    if drop_previous:
+        print("Removing previous ITIS data...")
+        cur.execute("""
+        DELETE FROM synonyms WHERE entity_id IN (
+            SELECT id FROM entities WHERE source = 'ITIS'
+        )""")
+        cur.execute("DELETE FROM entities WHERE source = 'ITIS'")
+        cur.execute("DELETE FROM metadata WHERE property = 'itis_version'")
+    current_itis_version = next(cur.execute("SELECT value FROM metadata WHERE property = 'itis_version'"), None)
+    if current_itis_version:
+        print("The species data has already been imported. Run this again with --drop-previous to re-import it.")
+        return
+    itis_db, itis_version = download_itis_database()
+    cur.execute("INSERT INTO metadata VALUES ('itis_version', ?)", (itis_version,))
+    itis_cur = itis_db.cursor()
+    results = itis_cur.execute("""
+    SELECT
+      tsn,
+      complete_name
+    FROM taxonomic_units
+    """)
+    cur.executemany("INSERT INTO entities VALUES (?, ?, 'species', 'ITIS')", [
+        ("tsn:" + str(result[0]), result[1])
+        for result in results])
+    connection.commit()
+    # synonyms_init is a temporary tables that is aggregated to generate the
+    # final synonyms table.
+    cur.execute("DROP TABLE IF EXISTS synonyms_init")
+    cur.execute("""
+    CREATE TABLE synonyms_init (
+        synonym TEXT, entity_id TEXT, weight INTEGER
+    )""")
+    insert_command = 'INSERT OR IGNORE INTO synonyms_init VALUES (?, ?, ?)'
+    # vern_ref_links and reference_links are used to weight the terms
+    query = itis_cur.execute("""
+    SELECT
+      tsn,
+      completename AS name,
+      count(documentation_id) AS refs
+    FROM longnames
+    LEFT JOIN reference_links USING (tsn)
+    GROUP BY tsn, completename
+    
+    UNION
+    
+    SELECT
+      tsn,
+      vernacular_name AS name,
+      count(documentation_id) AS refs
+    FROM vernaculars
+    LEFT JOIN vern_ref_links USING (tsn)
+    GROUP BY tsn, vernacular_name
+    """)
+    for batch in batched(query):
+        tuples = []
+        for result in batch:
+            tsn, name, refs = [x for x in result]
+            if refs >= 3:
+                weight = 3
+            else:
+                weight = refs
+            tuples.append((name, 'tsn:' + str(tsn), weight))
+        cur.executemany(insert_command, tuples)
+    print("Importing synonyms from ITIS database...")
+    cur.execute('''
+    INSERT INTO synonyms
+    SELECT synonym, entity_id, max(weight)
+    FROM synonyms_init
+    GROUP BY synonym, entity_id
+    ''')
+    cur.execute("DROP TABLE 'synonyms_init'")
+    connection.commit()
+    connection.close()
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--drop-previous", dest='drop_previous', action='store_true')
+    parser.set_defaults(drop_previous=False)
+    args = parser.parse_args()
+    import_species(args.drop_previous)

--- a/epitator/resolved_keyword_annotator.py
+++ b/epitator/resolved_keyword_annotator.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""Keyword Annotator"""
+"""Annotates keywords from the synonyms database
+and resolves them to uris."""
 from __future__ import absolute_import
 from collections import defaultdict
 from .annotator import Annotator, AnnoSpan, AnnoTier
@@ -7,30 +8,29 @@ from .ngram_annotator import NgramAnnotator
 from .get_database_connection import get_database_connection
 import sqlite3
 import logging
+
+
 logging.basicConfig(level=logging.ERROR, format='%(asctime)s %(message)s')
 logger = logging.getLogger(__name__)
 
 
 class ResolvedKeywordSpan(AnnoSpan):
-    def __init__(self, span, resolved_keywords, uris_to_labels):
+    def __init__(self, span, resolutions):
         self.__dict__ = dict(span.__dict__)
-        self.resolutions = []
-        self.uris = []
-        for keyword in sorted(resolved_keywords, key=lambda k: k['weight']):
-            if keyword['uri'] not in self.uris:
-                self.uris.append(keyword['uri'])
-                self.resolutions.append(dict(
-                    uri=keyword['uri'],
-                    weight=keyword['weight'],
-                    label=uris_to_labels[keyword['uri']]))
+        self.resolutions = resolutions
 
     def __repr__(self):
-        return super(ResolvedKeywordSpan, self).__repr__() + str(self.uris)
+        ids = [r['entity_id'] for r in self.resolutions]
+        return super(ResolvedKeywordSpan, self).__repr__() + str(ids)
 
     def to_dict(self):
         result = super(ResolvedKeywordSpan, self).to_dict()
-        result['resolutions'] = list(self.resolutions)
-        result['uris'] = list(self.uris)
+        result['resolutions'] = []
+        for res in self.resolutions:
+            res_dict = {k:res[k] for k in res.keys()}
+            entity = res['entity']
+            res_dict['entity'] = {k:entity[k] for k in entity.keys()}
+            result['resolutions'].append(res_dict)
         return result
 
 
@@ -38,6 +38,9 @@ class ResolvedKeywordAnnotator(Annotator):
     def __init__(self):
         self.connection = get_database_connection()
         self.connection.row_factory = sqlite3.Row
+        cursor = self.connection.cursor()
+        self.synonyms = list(cursor.execute("""
+        SELECT * FROM synonyms ORDER BY synonym"""))
 
     def annotate(self, doc):
         if 'ngrams' not in doc.tiers:
@@ -55,34 +58,44 @@ class ResolvedKeywordAnnotator(Annotator):
         cursor = self.connection.cursor()
 
         spans_to_resolved_keywords = defaultdict(list)
-        uris = set()
+        entity_ids = set()
         ordered_ngram_iter = iter(sorted(ngrams))
         try:
             ngram = next(ordered_ngram_iter)
-            for result in cursor.execute('SELECT * FROM synonyms ORDER BY synonym'):
+            for result in self.synonyms:
                 while ngram < result['synonym']:
                     ngram = next(ordered_ngram_iter)
                 if ngram == result['synonym']:
                     for span in span_text_to_spans[ngram]:
                         spans_to_resolved_keywords[span].append(result)
-                        uris.add(result['uri'])
+                        entity_ids.add(result['entity_id'])
         except StopIteration:
             pass
 
-        logger.info('%s uris resolved' % len(uris))
+        logger.info('%s entities resolved' % len(entity_ids))
 
         results = cursor.execute('''
-                                 SELECT *
-                                 FROM entity_labels
-                                 WHERE uri IN (''' +
-                                 ','.join('?' for x in uris) +
-                                 ')', list(uris))
-        uris_to_labels = {}
+             SELECT id, label, type
+             FROM entities
+             WHERE id IN (''' + ','.join('?' for x in entity_ids) + ')', list(entity_ids))
+        ids_to_entities = {}
         for result in results:
-            uris_to_labels[result['uri']] = result['label']
-
-        tier = AnnoTier([
-            ResolvedKeywordSpan(span, resolved_keywords, uris_to_labels)
-            for span, resolved_keywords in spans_to_resolved_keywords.items()])
+            ids_to_entities[result['id']] = result
+        spans = []
+        for span, resolved_keywords in spans_to_resolved_keywords.items():
+            sorted_resolved_keywords = sorted(resolved_keywords,
+                                              key=lambda k: k['weight'])
+            resolutions = []
+            span_entitiy_ids = set()
+            for keyword in sorted_resolved_keywords:
+                if keyword['entity_id'] in span_entitiy_ids:
+                    continue
+                span_entitiy_ids.add(keyword['entity_id'])
+                res_dict = {'entity_id': keyword['entity_id'],
+                            'entity': ids_to_entities[keyword['entity_id']],
+                            'weight': keyword['weight']}
+                resolutions.append(res_dict)
+            spans.append(ResolvedKeywordSpan(span, resolutions))
+        tier = AnnoTier(spans)
         tier.filter_overlapping_spans()
-        return { 'resolved_keywords': tier }
+        return {'resolved_keywords': tier}

--- a/epitator/utils.py
+++ b/epitator/utils.py
@@ -94,3 +94,17 @@ def parse_spelled_number(num_str):
         else:
             return None
     return sum(totals)
+
+
+def batched(iterable, batch_size=100):
+    """
+    Sequentially yield segments of the iterable in lists of the given size.
+    """
+    batch = []
+    for idx, item in enumerate(iterable):
+        batch.append(item)
+        batch_idx = idx % batch_size
+        if batch_idx == batch_size - 1:
+            yield batch
+            batch = []
+    yield batch

--- a/tests/annotator/test_db_interface.py
+++ b/tests/annotator/test_db_interface.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""
+Tests our ability to annotate sentences with numerical
+instances of infections, hospitalizations and deaths.
+"""
+from __future__ import absolute_import
+import unittest
+from . import test_utils
+from epitator.database_interface import DatabaseInterface
+
+class TestCountAnnotator(unittest.TestCase):
+
+    def setUp(self):
+        self.db_interface = DatabaseInterface()
+
+    def test_lookup_synonym(self):
+        results = self.db_interface.lookup_synonym('foot and mouth', 'disease')
+        self.assertEqual([{'synonym': u'hand, foot and mouth disease',
+                           'id': u'http://purl.obolibrary.org/obo/DOID_10881',
+                           'weight': 3,
+                           'label': u'hand, foot and mouth disease'}], list(results))
+
+    def test_get_entity(self):
+        result = self.db_interface.get_entity('http://purl.obolibrary.org/obo/DOID_4325')
+        self.assertEqual({'source': u'Disease Ontology',
+                          'type': u'disease',
+                          'id': u'http://purl.obolibrary.org/obo/DOID_4325',
+                          'label': u'Ebola hemorrhagic fever'}, result)

--- a/tests/annotator/test_geoname_annotator.py
+++ b/tests/annotator/test_geoname_annotator.py
@@ -25,7 +25,7 @@ class GeonameAnnotatorTest(unittest.TestCase):
         self.assertEqual(doc.text, text)
         self.assertEqual(len(doc.tiers['geonames'].spans), 1)
         self.assertEqual(doc.tiers['geonames'].spans[0].text, "Chicago")
-        self.assertEqual(doc.tiers['geonames'].spans[0].label, "Chicago")
+        self.assertEqual(doc.tiers['geonames'].spans[0].label, "City of Chicago")
         self.assertEqual(doc.tiers['geonames'].spans[0].start, 10)
         self.assertEqual(doc.tiers['geonames'].spans[0].end, 17)
 


### PR DESCRIPTION
This adds a ITIS data import script `python -m epitator.importers.import_species` that makes it possible for the resolved keyword annotator to annotate species names. This includes some refactoring that makes breaking changes to the embedded sqlite database and resolved keyword annotator.