### PR TITLE
Detect person descriptions as singular case counts

### DIFF
--- a/epitator/count_annotator.py
+++ b/epitator/count_annotator.py
@@ -60,6 +60,7 @@ def is_valid_count(count_string):
             return False
     except (TypeError, ValueError) as e:
         logger.info('Cannot parse count string: ' + count_string)
+        logger.info(str(e))
         return False
     if value > 1000000000:
         return False
@@ -183,11 +184,11 @@ class CountAnnotator(Annotator):
             max_dist=50)
         # Add singular case reports
         singular_case_spans = []
+        determiner_lemmas = set(['a', 'an', 'the'])
         for cd_span, token_group in case_descriptions.group_spans_by_containing_span(spacy_tokens):
             for t_span in token_group:
                 token = t_span.token
-                article_lemmas = set(['a', 'an', 'the'])
-                if token.tag_ == 'NN'and any(c.lower_ in article_lemmas
+                if token.tag_ == 'NN' and any(c.lower_ in determiner_lemmas
                                              for c in token.children):
                     singular_case_spans.append(cd_span)
                     break

--- a/epitator/date_annotator.py
+++ b/epitator/date_annotator.py
@@ -232,11 +232,11 @@ class DateAnnotator(Annotator):
                 relative_base_date = next((x for x in non_relative_dates if x),
                                           doc.date)
                 datetime_range_a = date_to_datetime_range(
-                        range_components[0],
-                        relative_base=relative_base_date)
+                    range_components[0],
+                    relative_base=relative_base_date)
                 datetime_range_b = date_to_datetime_range(
-                        range_components[1],
-                        relative_base=relative_base_date)
+                    range_components[1],
+                    relative_base=relative_base_date)
                 if datetime_range_a is None and datetime_range_b is None:
                     continue
                 elif datetime_range_a is None:

--- a/tests/annotator/test_count_annotator.py
+++ b/tests/annotator/test_count_annotator.py
@@ -288,7 +288,6 @@ Concerned citizens have said, "50,012, 412, 73, 200 and 16"
         self.assertHasCounts('They reported a patient infected with hepatitis B from a blood transfusion.',
                              [{'count': 1}])
 
-
     def test_singular_cases_4(self):
         self.assertHasCounts('the cases include a 27-year-old woman and 2 males, each of 37 years',
                              [{'count': 1}, {'count': 2}])

--- a/tests/annotator/test_count_annotator.py
+++ b/tests/annotator/test_count_annotator.py
@@ -20,7 +20,8 @@ class TestCountAnnotator(unittest.TestCase):
     def assertHasCounts(self, sent, counts):
         doc = AnnoDoc(sent)
         doc.add_tier(self.annotator)
-        self.assertEqual(len(doc.tiers['counts'].spans), len(counts))
+        if len(doc.tiers['counts'].spans) != len(counts):
+            self.assertEqual(doc.tiers['counts'].spans, counts)
         for actual, expected in zip(doc.tiers['counts'].spans, counts):
             test_utils.assertHasProps(actual.metadata, expected)
 
@@ -261,6 +262,7 @@ Concerned citizens have said, "50,012, 412, 73, 200 and 16"
 """
         expected_counts = [
             1,
+            1,
             5,
             2,
             19,
@@ -276,11 +278,20 @@ Concerned citizens have said, "50,012, 412, 73, 200 and 16"
 
     def test_singular_cases(self):
         self.assertHasCounts('The index case occured on January 22.', [
-            {'count': 1}])
+            {'count': 1, 'attributes': ['case']}])
 
     def test_singular_cases_2(self):
         self.assertHasCounts('A lassa fever case was reported in Hawaii', [
-            {'count': 1}])
+            {'count': 1, 'attributes': ['case']}])
+
+    def test_singular_cases_3(self):
+        self.assertHasCounts('They reported a patient infected with hepatitis B from a blood transfusion.',
+                             [{'count': 1}])
+
+
+    def test_singular_cases_4(self):
+        self.assertHasCounts('the cases include a 27-year-old woman and 2 males, each of 37 years',
+                             [{'count': 1}, {'count': 2}])
 
     def test_year_count(self):
         self.assertHasCounts("""As of [Sun 19 March 2017] (epidemiological week 11),

--- a/tests/annotator/test_date_annotator.py
+++ b/tests/annotator/test_date_annotator.py
@@ -180,5 +180,6 @@ class DateAnnotatorTest(unittest.TestCase):
             [datetime.datetime(2017, 3, 1),
              datetime.datetime(2017, 4, 1)])
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This simplifies the way that singular counts are identified so that any patient or case description that contains a singular noun with a determiner will be picked up. This makes it possible to correctly identify the counts in the examples that were added to test_count_annotator.py