### PR TITLE
Combine multipart geonames with more than 2 parts

### DIFF
--- a/epitator/annotier.py
+++ b/epitator/annotier.py
@@ -140,6 +140,15 @@ class AnnoTier(object):
     def combined_adjacent_spans(self, max_dist=1):
         """
         Create a new tier from groups of spans within max_dist of eachother.
+
+        >>> from .annospan import AnnoSpan
+        >>> from .annodoc import AnnoDoc
+        >>> doc = AnnoDoc('one two three four')
+        >>> tier = AnnoTier([AnnoSpan(0, 3, doc),
+        ...                  AnnoSpan(8, 13, doc),
+        ...                  AnnoSpan(14, 18, doc)])
+        >>> tier.combined_adjacent_spans()
+        [u'SpanGroup(text=one, label=None, 0-3:one)', u'SpanGroup(text=three four, label=None, 8-13:three, 14-18:four)']
         """
         prev_span = None
         span_groups = []

--- a/epitator/result_aggregators.py
+++ b/epitator/result_aggregators.py
@@ -42,6 +42,23 @@ def follows(results_lists, max_dist=1, allow_overlap=False, label=None):
     return [SpanGroup(seq, label) for seq in sequences]
 
 
+def n_or_more(n, results_list, max_dist=1):
+    """
+    Find sequences of n or more items from the results_list that follow eachother.
+    """
+    combined_spans = []
+    new_combined_spans = results_list
+    seq_len = 1
+    while True:
+        if seq_len >= n:
+            combined_spans += new_combined_spans
+        if len(new_combined_spans) == 0:
+            break
+        new_combined_spans = follows([new_combined_spans, results_list],
+                                     max_dist=max_dist)
+        seq_len += 1
+    return combined_spans
+
 def label(label, results_list):
     """
     Attach a label to the results so it can be looked up in a via groupdict.

--- a/tests/annotator/test_geoname_annotator.py
+++ b/tests/annotator/test_geoname_annotator.py
@@ -29,16 +29,24 @@ class GeonameAnnotatorTest(unittest.TestCase):
         self.assertEqual(doc.tiers['geonames'].spans[0].start, 10)
         self.assertEqual(doc.tiers['geonames'].spans[0].end, 17)
 
-    def test_mulipart_names(self):
-        text = 'I used to live in Seattle, WA'
+    def test_multipart_names(self):
+        text = 'From Seattle, WA, Canada is not far away.'
         doc = AnnoDoc(text)
         doc.add_tier(self.annotator)
 
         self.assertEqual(doc.text, text)
-        self.assertEqual(len(doc.tiers['geonames'].spans), 1)
+        self.assertEqual(len(doc.tiers['geonames'].spans), 2)
         self.assertEqual(doc.tiers['geonames'].spans[0].text, "Seattle, WA")
 
-    def test_mulipart_names3(self):
+    def test_multipart_names_2(self):
+        text = 'I used to live in Seattle, Washington, USA'
+        doc = AnnoDoc(text)
+        doc.add_tier(self.annotator)
+        self.assertEqual(doc.text, text)
+        self.assertEqual(len(doc.tiers['geonames'].spans), 1)
+        self.assertEqual(doc.tiers['geonames'].spans[0].text, "Seattle, Washington, USA")
+
+    def test_multipart_names_3(self):
         text = 'England, France, Germany and Italy are countries in Eurpoe'
         doc = AnnoDoc(text)
         doc.add_tier(self.annotator)


### PR DESCRIPTION
This makes it so all the geonames in a span like "Seattle, WA, USA" will be grouped into a single geoname for Seattle. Previously only two geonames could be grouped.