### PR TITLE
Extract purely numeric counts the NER is missing

### DIFF
--- a/epitator/count_annotator.py
+++ b/epitator/count_annotator.py
@@ -116,6 +116,9 @@ class CountAnnotator(Annotator):
                     match_spans.append(span)
             return AnnoTier(ra.label(match_name, match_spans))
 
+        # Add purely numeric counts that were not picked up by the NER.
+        counts += AnnoTier(search_regex(r'[1-9]\d{0,6}', 'count')
+                           ).without_overlaps(spacy_nes).spans
         # Add count ranges
         ranges = ra.follows([counts,
                              ra.label('range',
@@ -207,7 +210,6 @@ class CountAnnotator(Annotator):
             if case_count_sence_similary > non_case_count_sence_similary:
                 filtered_singular_case_spans.extend(group)
         singular_case_spans = filtered_singular_case_spans
-
         # remove counts that span multiple sentences
         all_potential_counts = reduce(lambda a, b: a + b, [
             case_descriptions_with_counts.spans,

--- a/epitator/spacy_annotator.py
+++ b/epitator/spacy_annotator.py
@@ -56,6 +56,8 @@ class SpacyAnnotator(Annotator):
                 elif token.ent_iob_ == "O":
                     ne_spans.append(AnnoSpan(start, end,
                                              doc, label=token.ent_type_))
+                else:
+                    raise Exception("Unexpected IOB tag: " + str(token.ent_iob_))
         if ne_chunk_start is not None:
             ne_spans.append(AnnoSpan(ne_chunk_start, ne_chunk_end,
                                      doc, label=ne_chunk_type))

--- a/tests/annotator/test_count_annotator.py
+++ b/tests/annotator/test_count_annotator.py
@@ -322,6 +322,46 @@ Concerned citizens have said, "50,012, 412, 73, 200 and 16"
                 'count': 26
             })
 
+    def test_count_list(self):
+        doc = AnnoDoc('''
+The 15 non-fatal cases confirmed across the state since the year began are as follows:
+
+ArithmeticError County - 1 case
+
+TypeError County - 1 case
+
+Python County - 2 cases
+
+Java County - 2 cases
+
+Scala County - 1 case
+
+Scheme County - 1 case
+
+Meteor County - 1 case
+
+Boolean County - 1 case (not including the fatality)
+
+Integer County - 3 cases
+''')
+        doc.add_tier(self.annotator)
+        expected_counts = [
+            15,
+            1,
+            1,
+            2,
+            2,
+            1,
+            1,
+            1,
+            1,
+            3
+        ]
+        actual_counts = [count.metadata['count']
+                         for count in doc.tiers['counts'].spans
+                         if 'case' in count.metadata['attributes']]
+        self.assertSequenceEqual(actual_counts, expected_counts)
+
     # Currently failing. Uncomment after spacy model update.
     # def test_counts_with_spaces(self):
     #     doc = AnnoDoc("Ther were 565 749 new cases")

--- a/tests/annotator/test_pos_annotator.py
+++ b/tests/annotator/test_pos_annotator.py
@@ -16,7 +16,7 @@ class POSAnnotatorTest(unittest.TestCase):
     def test_simple_sentence(self):
 
         self.doc = AnnoDoc("Hi Joe.")
-        sentence = self.annotator.annotate(self.doc)
+        self.annotator.annotate(self.doc)
 
         self.assertEqual(len(self.doc.tiers['pos'].spans), 3)
 
@@ -35,7 +35,7 @@ class POSAnnotatorTest(unittest.TestCase):
     def test_initial_space(self):
 
         self.doc = AnnoDoc(" Hi.")
-        sentence = self.annotator.annotate(self.doc)
+        self.annotator.annotate(self.doc)
 
         # This is true for the default wordpunct annotator, but not e.g. the
         # SpaceAnnotator
@@ -52,7 +52,7 @@ class POSAnnotatorTest(unittest.TestCase):
     def test_multiple_spaces_in_a_row(self):
 
         self.doc = AnnoDoc("         Hi  there      Joe  .")
-        sentence = self.annotator.annotate(self.doc)
+        self.annotator.annotate(self.doc)
 
         # This is true for the default wordpunct annotator, but not e.g. the
         # SpaceAnnotator

--- a/tests/annotator/test_token_annotator.py
+++ b/tests/annotator/test_token_annotator.py
@@ -15,7 +15,7 @@ class TokenAnnotatorTest(unittest.TestCase):
     def test_simple_sentence(self):
 
         self.doc = AnnoDoc("Hi Joe.")
-        sentence = self.annotator.annotate(self.doc)
+        self.annotator.annotate(self.doc)
 
         self.assertEqual(len(self.doc.tiers['tokens'].spans), 3)
 
@@ -34,7 +34,7 @@ class TokenAnnotatorTest(unittest.TestCase):
     def test_initial_space(self):
 
         self.doc = AnnoDoc(" Hi.")
-        sentence = self.annotator.annotate(self.doc)
+        self.annotator.annotate(self.doc)
 
         # This is true for the default wordpunct annotator, but not e.g. the
         # SpaceAnnotator
@@ -51,7 +51,7 @@ class TokenAnnotatorTest(unittest.TestCase):
     def test_multiple_spaces_in_a_row(self):
 
         self.doc = AnnoDoc("         Hi  there      Joe  .")
-        sentence = self.annotator.annotate(self.doc)
+        self.annotator.annotate(self.doc)
 
         # This is true for the default wordpunct annotator, but not e.g. the
         # SpaceAnnotator


### PR DESCRIPTION
The NER was missing a number of the counts in the count list test added in this PR so I added a regex to recognize counts composed entirely of digits.