### PR TITLE
Fix false negatives in count lists

### DIFF
--- a/epitator/annotier.py
+++ b/epitator/annotier.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 import json
 import six
-from . import maximum_weight_interval_set as mwis
 from . import result_aggregators as ra
 from .annospan import SpanGroup
 

--- a/epitator/geoname_annotator.py
+++ b/epitator/geoname_annotator.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 import math
 import re
-import itertools
 import sqlite3
 from collections import defaultdict
 from lazy import lazy

--- a/epitator/importers/import_disease_ontology.py
+++ b/epitator/importers/import_disease_ontology.py
@@ -13,6 +13,7 @@ from ..utils import batched
 
 DISEASE_ONTOLOGY_URL = "http://purl.obolibrary.org/obo/doid.owl"
 
+
 def import_disease_ontology(drop_previous=False):
     connection = get_database_connection(create_database=True)
     cur = connection.cursor()
@@ -126,7 +127,7 @@ def import_disease_ontology(drop_previous=False):
                 # capitalization is preserved.
                 tuples.append((syn_string, uri, weight))
         cur.executemany(insert_command, tuples)
-    # Extra synonyms not in the disease ontology
+    # Extra synonyms not in the disease ontology.
     cur.executemany(insert_command, [
         ('HIV', 'http://purl.obolibrary.org/obo/DOID_526', 3),
         ('Ebola', 'http://purl.obolibrary.org/obo/DOID_4325', 3),

--- a/epitator/importers/import_species.py
+++ b/epitator/importers/import_species.py
@@ -16,6 +16,7 @@ from ..utils import batched
 
 ITIS_URL = "https://www.itis.gov/downloads/itisSqlite.zip"
 
+
 # The data model for the itis database is available here:
 # https://www.itis.gov/pdf/ITIS_ConceptualModelEntityDefinition.pdf
 def download_itis_database():

--- a/epitator/importers/import_wikidata.py
+++ b/epitator/importers/import_wikidata.py
@@ -10,6 +10,7 @@ from urllib import urlopen, urlencode
 import json
 import datetime
 
+
 def import_wikidata(drop_previous=False):
     connection = get_database_connection(create_database=True)
     cur = connection.cursor()
@@ -46,6 +47,20 @@ def import_wikidata(drop_previous=False):
     cur.executemany("INSERT INTO synonyms VALUES (?, ?, 1)", [
         (result['itemLabel']['value'], result['item']['value'])
         for result in results])
+    print("Importing manually added diseases not in disease ontology...")
+    # Wikidata entities are used in place of those from the disease ontology.
+    cur.execute("""
+                INSERT INTO entities VALUES
+                ('https://www.wikidata.org/wiki/Q16654806',
+                 'Middle East respiratory syndrome',
+                 'disease', 'Wikidata'
+                )""")
+    cur.executemany("INSERT INTO synonyms VALUES (?, ?, ?)", [
+        ('Middle East respiratory syndrome', 'https://www.wikidata.org/wiki/Q16654806', 3),
+        ('MERS', 'https://www.wikidata.org/wiki/Q16654806', 3),
+        ('Middle East respiratory syndrome coronavirus', 'https://www.wikidata.org/wiki/Q16654806', 3),
+        ('MERS-CoV', 'https://www.wikidata.org/wiki/Q16654806', 3),
+    ])
     connection.commit()
     connection.close()
 

--- a/epitator/maximum_weight_interval_set.py
+++ b/epitator/maximum_weight_interval_set.py
@@ -5,7 +5,7 @@ class Interval():
         self.weight = weight
         self.corresponding_object = corresponding_object
         # The combined weight of the MWIS prior to this interval.
-        self.__value__ = 0.0
+        self.__value__ = None
         # The previous inverval in the MWIS prior to this interval.
         self.__previous__ = None
 
@@ -53,6 +53,7 @@ def find_maximum_weight_interval_set(intervals):
     """
     Takes a list of weighted intervals and returns a non-overlapping set of them
     with the maximum possible weight.
+    Weights may be numeric or numeric tuples.
     There are some edge-cases to consider in determining what constitutes an
     overlap in relation to end-points and zero length intervals.
     The intervals are left-closed. If the left endpoints of two zero
@@ -72,7 +73,11 @@ def find_maximum_weight_interval_set(intervals):
         if endpoint.is_start:
             endpoint.interval.__value__ = endpoint.interval.weight
             if max_interval_sofar:
-                endpoint.interval.__value__ += max_interval_sofar.__value__
+                if isinstance(max_interval_sofar.__value__, tuple):
+                    endpoint.interval.__value__ = tuple(map(sum, zip(max_interval_sofar.__value__,
+                                                               endpoint.interval.__value__)))
+                else:
+                    endpoint.interval.__value__ += max_interval_sofar.__value__
                 endpoint.interval.__previous__ = max_interval_sofar
         else:  # endoint.is_end
             if not max_interval_sofar:

--- a/epitator/maximum_weight_interval_set.py
+++ b/epitator/maximum_weight_interval_set.py
@@ -18,6 +18,7 @@ class Interval():
     def __len__(self):
         return self.end - self.start
 
+
 class Endpoint():
     def __init__(self, interval, is_start):
         self.interval = interval
@@ -75,7 +76,7 @@ def find_maximum_weight_interval_set(intervals):
             if max_interval_sofar:
                 if isinstance(max_interval_sofar.__value__, tuple):
                     endpoint.interval.__value__ = tuple(map(sum, zip(max_interval_sofar.__value__,
-                                                               endpoint.interval.__value__)))
+                                                                     endpoint.interval.__value__)))
                 else:
                     endpoint.interval.__value__ += max_interval_sofar.__value__
                 endpoint.interval.__previous__ = max_interval_sofar

--- a/epitator/result_aggregators.py
+++ b/epitator/result_aggregators.py
@@ -95,6 +95,7 @@ def combine(results_lists, prefer="first"):
             return len(set(x.iterate_leaf_base_spans()))
         else:
             return 1
+
     def num_spans_and_no_linebreaks(x):
         """
         Same as num_spans, but linebreaks are avoided as a secondary objective.

--- a/epitator/result_aggregators.py
+++ b/epitator/result_aggregators.py
@@ -95,12 +95,20 @@ def combine(results_lists, prefer="first"):
             return len(set(x.iterate_leaf_base_spans()))
         else:
             return 1
+    def num_spans_and_no_linebreaks(x):
+        """
+        Same as num_spans, but linebreaks are avoided as a secondary objective.
+        """
+        return num_spans(x), int("\n" not in x.text)
+
     if prefer == "first":
         prefunc = first
     elif prefer == "text_length":
         prefunc = text_length
     elif prefer == "num_spans":
         prefunc = num_spans
+    elif prefer == "num_spans_and_no_linebreaks":
+        prefunc = num_spans_and_no_linebreaks
     else:
         prefunc = prefer
     my_mwis = mwis.find_maximum_weight_interval_set([

--- a/epitator/result_aggregators.py
+++ b/epitator/result_aggregators.py
@@ -59,6 +59,7 @@ def n_or_more(n, results_list, max_dist=1):
         seq_len += 1
     return combined_spans
 
+
 def label(label, results_list):
     """
     Attach a label to the results so it can be looked up in a via groupdict.

--- a/tests/annotator/test_count_annotator.py
+++ b/tests/annotator/test_count_annotator.py
@@ -185,9 +185,8 @@ Ongoing cases: 7
     def test_attributes(self):
         self.assertHasCounts('There have been 12 reported cases in Colorado. '
                              'There was one suspected case of bird flu in the country.',
-                             [
-                                {'count': 12, 'attributes': ['case']},
-                                {'count': 1, 'attributes': ['case', 'suspected']}])
+                             [{'count': 12, 'attributes': ['case']},
+                              {'count': 1, 'attributes': ['case', 'suspected']}])
 
     def test_attributes_2(self):
         self.assertHasCounts('The average number of cases reported annually is 600',
@@ -361,7 +360,7 @@ Integer County - 3 cases
         self.assertSequenceEqual(actual_counts, expected_counts)
 
     def test_count_list_2(self):
-        doc = AnnoDoc("Ica 562 cases, Chincha 17 cases, Nasca 152 cases, Palpa 409 cases, Pisco 299 cases.")
+        doc = AnnoDoc('Ica 562 cases, Chincha 17 cases, Nasca 152 cases, Palpa 409 cases, Pisco 299 cases.')
         doc.add_tier(self.annotator)
         expected_counts = [
             562,
@@ -378,7 +377,7 @@ Integer County - 3 cases
     def test_attribute_fp(self):
         # Make sure the count is not parsed as incremental becasue of the
         # new in New York.
-        self.assertHasCounts("5 cases of Dengue in New York.", [
+        self.assertHasCounts('5 cases of Dengue in New York.', [
             {'attributes': ['case']}])
 
     # Currently failing. Uncomment after spacy model update.

--- a/tests/annotator/test_date_annotator.py
+++ b/tests/annotator/test_date_annotator.py
@@ -180,6 +180,15 @@ class DateAnnotatorTest(unittest.TestCase):
             [datetime.datetime(2017, 3, 1),
              datetime.datetime(2017, 4, 1)])
 
+    def test_since_date(self):
+        text = 'nearly 5000 cases have been reported since 1 Sep 2010.'
+        doc = AnnoDoc(text, date=datetime.datetime(2010, 12, 10))
+        doc.add_tier(self.annotator)
+        self.assertEqual(
+            doc.tiers['dates'].spans[0].datetime_range,
+            [datetime.datetime(2010, 9, 1),
+             datetime.datetime(2010, 12, 10)])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/annotator/test_resolved_keyword_annotator.py
+++ b/tests/annotator/test_resolved_keyword_annotator.py
@@ -39,6 +39,13 @@ class ResolvedKeywordAnnotatorTest(unittest.TestCase):
                                       expected_uris):
             self.assertEqual(span.resolutions[0]['entity_id'], expected_uri)
 
+    def test_MERS(self):
+        doc = AnnoDoc('There have been 6 new cases of MERS since last week.')
+        doc.add_tier(self.annotator)
+        first_span = doc.tiers['resolved_keywords'].spans[0]
+        self.assertEqual(first_span.resolutions[0]['entity_id'],
+                         'https://www.wikidata.org/wiki/Q16654806')
+
     def test_acroynms(self):
         doc = AnnoDoc("Ebola Virus disease is EVD")
         doc.add_tier(self.annotator)


### PR DESCRIPTION
This makes some changes to the count annotator to prevent counts in lists from being incorrectly parsed. This also adds and 'ongoing' count attribute and tuple support in the MWIS algorithm.