### PR TITLE
Improve date string cleaning

### DIFF
--- a/epitator/annotier.py
+++ b/epitator/annotier.py
@@ -131,6 +131,19 @@ class AnnoTier(object):
                 result.append(span)
         return AnnoTier(result)
 
+    def with_contained_spans_from(self, other_tier, allow_partial_containment=False):
+        """
+        Create a new tier from pairs spans in this tier and the other tier
+        where the span in this tier contains one in the other tier.
+        """
+        span_groups = self.group_spans_by_containing_span(other_tier,
+                                                          allow_partial_containment=allow_partial_containment)
+        result = []
+        for span, group in span_groups:
+            for other_span in group:
+                result.append(SpanGroup([span, other_span]))
+        return AnnoTier(result)
+
     def with_nearby_spans_from(self, other_tier, max_dist=100):
         """
         Create a new tier from pairs spans in this tier and the other tier

--- a/epitator/date_annotator.py
+++ b/epitator/date_annotator.py
@@ -51,6 +51,7 @@ ordinal_date_re = re.compile(
     r"(?P<rest>.{3,})", re.I)
 ends_with_timeunit_re = re.compile(r".*(months|days|years)$", re.I)
 
+
 class DateSpan(AnnoSpan):
     def __init__(self, base_span, datetime_range):
         self.start = base_span.start
@@ -81,7 +82,7 @@ class DateAnnotator(Annotator):
     would be parsed as a range from the start of the day to the end of the day,
     while a month like "December 2011" would be parsed as a range from the start
     of December 1st ending at the start of January 1st 2012.
-    
+
     Args:
         include_end_date (bool): Indicates whether a date range like "Monday to
         Wednesday" should be parsed as ending at the start of Wednesday
@@ -222,7 +223,8 @@ class DateAnnotator(Annotator):
         since_tokens = ra.label('since_token', [
             t_span for t_span in doc.tiers['spacy.tokens']
             if 'since' == t_span.token.lemma_])
-        since_date_spans = ra.label('since_date',
+        since_date_spans = ra.label(
+            'since_date',
             ra.follows([since_tokens, date_span_tier], allow_overlap=True) +
             date_span_tier.with_contained_spans_from(since_tokens).spans)
         tier_spans = []

--- a/tests/annotator/test_date_annotator.py
+++ b/tests/annotator/test_date_annotator.py
@@ -195,6 +195,22 @@ class DateAnnotatorTest(unittest.TestCase):
             [datetime.datetime(2010, 9, 1),
              datetime.datetime(2010, 12, 10)])
 
+    def test_long_entity_dates(self):
+        # This tests dates that are extracted with peripheral text
+        # by the current NER.
+        doc = AnnoDoc("""
+In the month of August 2017, there were a total of 3 laboratory confirmed cases.
+For the 1st time since 1998, a case of yellow fever has been confirmed.
+""", date=datetime.datetime(2017, 12, 10))
+        doc.add_tier(self.annotator)
+        self.assertEqual(
+            doc.tiers['dates'].spans[0].datetime_range,
+            [datetime.datetime(2017, 8, 1),
+             datetime.datetime(2017, 9, 1)])
+        self.assertEqual(
+            doc.tiers['dates'].spans[1].datetime_range,
+            [datetime.datetime(1998, 1, 1),
+             datetime.datetime(2017, 12, 10)])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/annotator/test_date_annotator.py
+++ b/tests/annotator/test_date_annotator.py
@@ -212,5 +212,6 @@ For the 1st time since 1998, a case of yellow fever has been confirmed.
             [datetime.datetime(1998, 1, 1),
              datetime.datetime(2017, 12, 10)])
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This removes peripheral text from date strings like "The month of" in "The month of March" in more cases so the date component can be parsed. It also identifies "since" tokens contained within date strings.