### PR TITLE
Convenience methods

### DIFF
--- a/epitator/annotier.py
+++ b/epitator/annotier.py
@@ -92,11 +92,10 @@ class AnnoTier(object):
                 other_span_idx_2 += 1
             yield span, span_group
 
-
     def spans_contained_by_span(self, selector_span):
         """
         Return a list of spans that are contained by a "selector span".
-        
+
         >>> from epitator.annospan import AnnoSpan
         >>> from epitator.annodoc import AnnoDoc
         >>> from epitator.annotier import AnnoTier

--- a/epitator/annotier.py
+++ b/epitator/annotier.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 import json
 import six
+from itertools import compress
 from . import result_aggregators as ra
 from .annospan import SpanGroup, AnnoSpan
 
@@ -88,6 +89,43 @@ class AnnoTier(object):
                 span_group.append(other_spans[other_span_idx_2])
                 other_span_idx_2 += 1
             yield span, span_group
+
+
+    def spans_contained_by_span(self, selector_span):
+        """
+        Return a list of spans that are contained by a "selector span".
+
+        >>> from epitator.annospan import AnnoSpan
+        >>> from epitator.annodoc import AnnoDoc
+        >>> from epitator.annotier import AnnoTier
+        >>> doc = AnnoDoc('one two three')
+        >>> tier1 = AnnoTier([AnnoSpan(0, 3, doc), AnnoSpan(4, 7, doc)])
+        >>> span1 = AnnoSpan(3, 9, doc)
+        >>> tier1.spans_overlapped_by_span(span1)
+        [4-7:two]
+        """
+        selectors = [selector_span.contains(span) for span in self.spans]
+        return(
+            list(compress(self.spans, selectors))
+        )
+
+    def spans_overlapped_by_span(self, selector_span):
+        """
+        Return a list of spans that overlap a "selector span".
+
+        >>> from epitator.annospan import AnnoSpan
+        >>> from epitator.annodoc import AnnoDoc
+        >>> from epitator.annotier import AnnoTier
+        >>> doc = AnnoDoc('one two three')
+        >>> tier1 = AnnoTier([AnnoSpan(0, 3, doc), AnnoSpan(4, 7, doc)])
+        >>> span1 = AnnoSpan(0, 1, doc)
+        >>> tier1.spans_overlapped_by_span(span1)
+        [0-3:one]
+        """
+        selectors = [selector_span.overlaps(span) for span in self.spans]
+        return(
+            list(compress(self.spans, selectors))
+        )
 
     def with_label(self, label):
         """

--- a/epitator/annotier.py
+++ b/epitator/annotier.py
@@ -37,6 +37,9 @@ class AnnoTier(object):
     def __iter__(self):
         return iter(self.spans)
 
+    def __getitem__(self, idx):
+        return self.spans[idx]
+
     def to_json(self):
         docless_spans = []
         for span in self.spans:

--- a/epitator/annotier.py
+++ b/epitator/annotier.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 import json
 import six
-from itertools import compress
 from . import result_aggregators as ra
 from .annospan import SpanGroup, AnnoSpan
 
@@ -97,19 +96,18 @@ class AnnoTier(object):
     def spans_contained_by_span(self, selector_span):
         """
         Return a list of spans that are contained by a "selector span".
-
+        
         >>> from epitator.annospan import AnnoSpan
         >>> from epitator.annodoc import AnnoDoc
         >>> from epitator.annotier import AnnoTier
         >>> doc = AnnoDoc('one two three')
         >>> tier1 = AnnoTier([AnnoSpan(0, 3, doc), AnnoSpan(4, 7, doc)])
         >>> span1 = AnnoSpan(3, 9, doc)
-        >>> tier1.spans_overlapped_by_span(span1)
-        [4-7:two]
+        >>> tier1.spans_contained_by_span(span1)
+        AnnoTier([4-7:two])
         """
-        selectors = [selector_span.contains(span) for span in self.spans]
         return(
-            list(compress(self.spans, selectors))
+            AnnoTier([span for span in self if selector_span.contains(span)])
         )
 
     def spans_overlapped_by_span(self, selector_span):
@@ -123,11 +121,10 @@ class AnnoTier(object):
         >>> tier1 = AnnoTier([AnnoSpan(0, 3, doc), AnnoSpan(4, 7, doc)])
         >>> span1 = AnnoSpan(0, 1, doc)
         >>> tier1.spans_overlapped_by_span(span1)
-        [0-3:one]
+        AnnoTier([0-3:one])
         """
-        selectors = [selector_span.overlaps(span) for span in self.spans]
         return(
-            list(compress(self.spans, selectors))
+            AnnoTier([span for span in self if selector_span.overlaps(span)])
         )
 
     def with_label(self, label):

--- a/epitator/date_annotator.py
+++ b/epitator/date_annotator.py
@@ -211,7 +211,7 @@ class DateAnnotator(Annotator):
 
         def is_individually_parsable(text):
             try:
-                return strict_parser.get_date_data(text)['date_obj'] != None
+                return strict_parser.get_date_data(text)['date_obj'] is not None
             except TypeError:
                 return False
         for date_group in adjacent_date_spans:

--- a/tests/annotator/test_date_annotator.py
+++ b/tests/annotator/test_date_annotator.py
@@ -108,7 +108,6 @@ class DateAnnotatorTest(unittest.TestCase):
         doc = AnnoDoc(text)
         doc.add_tier(self.annotator)
 
-
     def test_dateparse_bug_2(self):
         # The current version of the date annotator tries to parse 72\n1994, which triggers an exception
         # in the dateparse library.


### PR DESCRIPTION
I added two main changes:

- Two `AnnoTier` methods for returning the spans overlapped and contained by a provided span, respectively.
- A short `__getitem__()` method which lets you index a tier as `tier[1]` and `tier[0:4]` without having to write `tier.spans[0:4]`. This is a small convenience, but it's a mistake I kept making working with the class. It makes it semantically consistent with `for span in tier:`, which works.