### PR TITLE
Add dedicated species annotator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Usage
     doc = AnnoDoc("5 cases of smallpox")
     doc.add_tiers(ResolvedKeywordAnnotator())
     annotations = doc.tiers["resolved_keywords"].spans
-    annotations[0].resolutions
+    annotations[0].metadata["resolutions"]
     # = [{'entity': <sqlite3.Row>, 'entity_id': u'http://purl.obolibrary.org/obo/DOID_8736', 'weight': 3}]
 
 
@@ -127,8 +127,35 @@ Usage
     doc = AnnoDoc("From March 5 until April 7 1988")
     doc.add_tiers(DateAnnotator())
     annotations = doc.tiers["dates"].spans
-    annotations[0].datetime_range
+    annotations[0].metadata["datetime_range"]
     # = [datetime.datetime(1988, 3, 5, 0, 0), datetime.datetime(1988, 4, 7, 0, 0)]
+
+
+Structured Data Annotator
+--------------
+
+The structured data annotator identifies and parses embedded tables.
+
+Usage
+-----
+
+.. code:: python
+
+    from epitator.annotator import AnnoDoc
+    from epitator.structured_data_annotator import StructuredDataAnnotator
+    doc = AnnoDoc("""
+    species | cases | deaths
+    Cattle  | 0     | 0
+    Dogs    | 2     | 1
+    """)
+    doc.add_tiers(StructuredDataAnnotator())
+    annotations = doc.tiers["structured_data"].spans
+    annotations[0].metadata
+    # = {'data': [
+    #       [AnnoSpan(1-8, species), AnnoSpan(11-16, cases), AnnoSpan(19-25, deaths)],
+    #       [AnnoSpan(26-32, Cattle), AnnoSpan(36-37, 0), AnnoSpan(44-45, 0)],
+    #       [AnnoSpan(46-50, Dogs), AnnoSpan(56-57, 2), AnnoSpan(64-65, 1)]],
+    #    'type': 'table'}
 
 
 Architecture

--- a/epitator/annodoc.py
+++ b/epitator/annodoc.py
@@ -36,6 +36,25 @@ class AnnoDoc(object):
             self.tiers.update(result)
         return self
 
+    def require_tiers(self, *tier_names, **kwargs):
+        """
+        Return the specified tiers or add them using the via annotator.
+        """
+        assert len(set(kwargs.keys()) | set(['via'])) == 1
+        assert len(tier_names) > 0
+        via_annotator = kwargs.get('via')
+        tiers = [self.tiers.get(tier_name) for tier_name in tier_names]
+        if all(t is not None for t in tiers):
+            if len(tiers) == 1:
+                return tiers[0]
+            return tiers
+        else:
+            if via_annotator:
+                self.add_tiers(via_annotator())
+                return self.require_tiers(*tier_names)
+            else:
+                raise Exception("Tier could not be found. Available tiers: " + str(self.tiers.keys()))
+
     def create_regex_tier(self, regex, label=None):
         """
         Create an AnnoTier from all the spans of text that match the regex.

--- a/epitator/importers/import_species.py
+++ b/epitator/importers/import_species.py
@@ -109,6 +109,17 @@ def import_species(drop_previous=False):
                 weight = refs
             tuples.append((name, 'tsn:' + str(tsn), weight))
         cur.executemany(insert_command, tuples)
+    print("Importing hard-coded species names")
+    cur.executemany(insert_command, [
+        ('man', 'tsn:180092', 3),
+        ('men', 'tsn:180092', 3),
+        ('woman', 'tsn:180092', 3),
+        ('women', 'tsn:180092', 3),
+        ('human', 'tsn:180092', 3),
+        ('humans', 'tsn:180092', 3),
+        ('person', 'tsn:180092', 3),
+        ('people', 'tsn:180092', 3),
+    ])
     print("Importing synonyms from ITIS database...")
     cur.execute('''
     INSERT INTO synonyms

--- a/epitator/resolved_keyword_annotator.py
+++ b/epitator/resolved_keyword_annotator.py
@@ -84,7 +84,9 @@ class ResolvedKeywordAnnotator(Annotator):
                     else:
                         match_weight = 0
                     for span in span_text_to_spans[ngram]:
-                        spans_to_resolved_keywords[span].append(dict(result, weight=result['weight'] + match_weight))
+                        spans_to_resolved_keywords[span].append(
+                            dict(result,
+                                 weight=result['weight'] + match_weight))
                         entity_ids.add(result['entity_id'])
         except StopIteration:
             pass

--- a/epitator/species_annotator.py
+++ b/epitator/species_annotator.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from .annotator import Annotator, AnnoSpan, AnnoTier
+from .resolved_keyword_annotator import ResolvedKeywordAnnotator
+from .geoname_annotator import GeonameAnnotator
+from .spacy_annotator import SpacyAnnotator
+
+
+class SpeciesAnnotator(Annotator):
+    def annotate(self, doc):
+        named_entities = doc.require_tiers('spacy.nes', via=SpacyAnnotator)
+        geonames = doc.require_tiers('geonames', via=GeonameAnnotator)
+        resolved_keywords = doc.require_tiers('resolved_keywords', via=ResolvedKeywordAnnotator)
+        species_list = []
+        for kw_span in resolved_keywords:
+            first_resolution = kw_span.metadata['resolutions'][0]
+            if first_resolution['entity']['type'] == 'species':
+                species_list.append(AnnoSpan(kw_span.start, kw_span.end, kw_span.doc, metadata={
+                    'species': {
+                        'id': first_resolution['entity']['id'],
+                        'label': first_resolution['entity']['label'],
+                    }
+                }))
+        species_tier = AnnoTier(species_list, presorted=True)
+        return {
+            'species': species_tier.without_overlaps(geonames).without_overlaps(named_entities)
+        }

--- a/tests/annotator/test_species_annotator.py
+++ b/tests/annotator/test_species_annotator.py
@@ -5,6 +5,7 @@ from . import test_utils
 from epitator.annotator import AnnoDoc
 from epitator.species_annotator import SpeciesAnnotator
 
+
 class SpeciesAnnotatorTest(unittest.TestCase):
     def setUp(self):
         self.annotator = SpeciesAnnotator()
@@ -32,6 +33,5 @@ and Sierra Leone 11 new cases and 2 deaths.""")
 5 humans were infected - 4 men and 1 woman. One infected person was admitted to the hospital.""")
         doc.add_tier(self.annotator)
         self.assertEqual(len(doc.tiers['species']), 4)
-        self.assertTrue(all(s.metadata['species']['id'] == 'tsn:180092' 
+        self.assertTrue(all(s.metadata['species']['id'] == 'tsn:180092'
                             for s in doc.tiers['species']))
-

--- a/tests/annotator/test_species_annotator.py
+++ b/tests/annotator/test_species_annotator.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+import unittest
+from . import test_utils
+from epitator.annotator import AnnoDoc
+from epitator.species_annotator import SpeciesAnnotator
+
+class SpeciesAnnotatorTest(unittest.TestCase):
+    def setUp(self):
+        self.annotator = SpeciesAnnotator()
+
+    def test_species(self):
+        doc = AnnoDoc("His illness was caused by cattle")
+        doc.add_tier(self.annotator)
+        test_utils.assertHasProps(doc.tiers['species'].spans[-1].metadata, {
+            'species': {
+                'id': 'tsn:180704',
+                'label': 'Bovidae'}
+        })
+
+    def test_species_false_positive(self):
+        # Sierra wil be detected as a species if using naive ontology keyword
+        # matching.
+        doc = AnnoDoc("""
+Guinea, 3 new cases and 5 deaths; Liberia, 8 new cases with 7 deaths;
+and Sierra Leone 11 new cases and 2 deaths.""")
+        doc.add_tier(self.annotator)
+        self.assertEqual(len(doc.tiers['species']), 0)
+
+    def test_species_humans(self):
+        doc = AnnoDoc("""
+5 humans were infected - 4 men and 1 woman. One infected person was admitted to the hospital.""")
+        doc.add_tier(self.annotator)
+        self.assertEqual(len(doc.tiers['species']), 4)
+        self.assertTrue(all(s.metadata['species']['id'] == 'tsn:180092' 
+                            for s in doc.tiers['species']))
+


### PR DESCRIPTION
This adds a dedicated species annotator. The reason a dedicated annotator is used instead of the resolved keyword annotator is so species name specific logic can be used to remove some of the matches. For instance, the resolved keyword annotator could foreseeably be used with a lexicon of location names, so removing genome matches from its matches is not always appropriate. However, that can always be done to species names. This also adds some synonyms for humans to the keyword resolver lexicon, and there is a new Annodoc.require_tiers method meant to reduce the amount of boilerplate code needed to handle dependencies between annotators.