### PR TITLE
Replace broken doc.to_json method with doc.to_dict

### DIFF
--- a/epitator/annodoc.py
+++ b/epitator/annodoc.py
@@ -80,9 +80,9 @@ class AnnoDoc(object):
         >>> doc.tiers = {
         ...     'test': AnnoTier([AnnoSpan(0, 3, doc), AnnoSpan(4, 7, doc)])}
         >>> d = doc.to_dict()
-        >>> d['text']
+        >>> str(d['text'])
         'one two three'
-        >>> d['date']
+        >>> str(d['date'])
         '2011-11-11T00:00:00Z'
         >>> sorted(d['tiers']['test'][0].items())
         [('label', None), ('textOffsets', [[0, 3]])]

--- a/epitator/annospan.py
+++ b/epitator/annospan.py
@@ -139,13 +139,17 @@ class AnnoSpan(object):
         >>> number_span_g = SpanGroup([AnnoSpan(0, 3, doc, 'number'),
         ...                            AnnoSpan(4, 7, doc, 'number'),
         ...                            AnnoSpan(8, 12, doc, 'animal')])
-        >>> number_span_g.groupdict()
-        {'number': [AnnoSpan(0-3, number), AnnoSpan(4-7, number)], 'animal': [AnnoSpan(8-12, animal)]}
+        >>> number_span_g.groupdict()['number']
+        [AnnoSpan(0-3, number), AnnoSpan(4-7, number)]
+        >>> number_span_g.groupdict()['animal']
+        [AnnoSpan(8-12, animal)]
         """
         out = {}
         for base_span in self.base_spans:
             for key, values in base_span.groupdict().items():
                 out[key] = out.get(key, []) + values
+        for values in out.values():
+            values.sort()
         if self.label:
             out[self.label] = [self]
         return out

--- a/epitator/annotier.py
+++ b/epitator/annotier.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # coding=utf8
 from __future__ import absolute_import
-import json
 import re
 from .annospan import SpanGroup, AnnoSpan
 from . import maximum_weight_interval_set as mwis
@@ -38,14 +37,6 @@ class AnnoTier(object):
 
     def __getitem__(self, idx):
         return self.spans[idx]
-
-    def to_json(self):
-        docless_spans = []
-        for span in self.spans:
-            span_dict = span.__dict__.copy()
-            del span_dict['doc']
-            docless_spans.append(span_dict)
-        return json.dumps(docless_spans)
 
     def group_spans_by_containing_span(self,
                                        other_tier,


### PR DESCRIPTION
I switched to returning dictionaries because they allow the data to be more easily modified, and the json string serialization can be accomplished with a call to json.dumps later on. The to_dict function is intended for one-way serialization. It includes the document text and span offsets but leaves out some metadata and object type information. To serialize a document in a way that allows it to be reconstructed the pickle or jsonpickle library should be used.
