### PR TITLE
 Add command-line flags to set proxy for importers

### DIFF
--- a/epitator/importers/import_all.py
+++ b/epitator/importers/import_all.py
@@ -18,9 +18,23 @@ if __name__ == '__main__':
         "--drop-previous", dest='drop_previous', action='store_true')
     parser.add_argument(
         "--accept-licenses", dest='accept_licenses', action='store_true')
+    parser.add_argument("--http_proxy",
+                        dest="http_proxy")
+    parser.add_argument("--https_proxy",
+                        dest="https_proxy")
     parser.set_defaults(drop_previous=False)
+    parser.set_defaults(http_proxy=None)
+    parser.set_defaults(https_proxy=None)
     args = parser.parse_args()
-    import_disease_ontology(args.drop_previous)
-    import_species(args.drop_previous)
-    import_geonames(args.drop_previous)
-    import_wikidata(args.drop_previous)
+    import_disease_ontology(drop_previous=args.drop_previous,
+                            http_proxy=args.http_proxy,
+                            https_proxy=args.https_proxy)
+    import_species(drop_previous=args.drop_previous,
+                   http_proxy=args.http_proxy,
+                   https_proxy=args.https_proxy)
+    import_geonames(drop_previous=args.drop_previous,
+                    http_proxy=args.http_proxy,
+                    https_proxy=args.https_proxy)
+    import_wikidata(drop_previous=args.drop_previous,
+                    http_proxy=args.http_proxy,
+                    https_proxy=args.https_proxy)

--- a/epitator/importers/import_all.py
+++ b/epitator/importers/import_all.py
@@ -18,23 +18,9 @@ if __name__ == '__main__':
         "--drop-previous", dest='drop_previous', action='store_true')
     parser.add_argument(
         "--accept-licenses", dest='accept_licenses', action='store_true')
-    parser.add_argument("--http_proxy",
-                        dest="http_proxy")
-    parser.add_argument("--https_proxy",
-                        dest="https_proxy")
     parser.set_defaults(drop_previous=False)
-    parser.set_defaults(http_proxy=None)
-    parser.set_defaults(https_proxy=None)
     args = parser.parse_args()
-    import_disease_ontology(drop_previous=args.drop_previous,
-                            http_proxy=args.http_proxy,
-                            https_proxy=args.https_proxy)
-    import_species(drop_previous=args.drop_previous,
-                   http_proxy=args.http_proxy,
-                   https_proxy=args.https_proxy)
-    import_geonames(drop_previous=args.drop_previous,
-                    http_proxy=args.http_proxy,
-                    https_proxy=args.https_proxy)
-    import_wikidata(drop_previous=args.drop_previous,
-                    http_proxy=args.http_proxy,
-                    https_proxy=args.https_proxy)
+    import_disease_ontology(args.drop_previous)
+    import_species(args.drop_previous)
+    import_geonames(args.drop_previous)
+    import_wikidata(args.drop_previous)

--- a/epitator/importers/import_disease_ontology.py
+++ b/epitator/importers/import_disease_ontology.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 import rdflib
 import re
-import os
 from six.moves.urllib.error import URLError
 from ..get_database_connection import get_database_connection
 from ..utils import batched
@@ -16,7 +15,7 @@ from ..utils import batched
 DISEASE_ONTOLOGY_URL = "http://purl.obolibrary.org/obo/doid.owl"
 
 
-def import_disease_ontology(drop_previous=False, root_uri=None, http_proxy=None, https_proxy=None):
+def import_disease_ontology(drop_previous=False, root_uri=None):
     if not root_uri:
         root_uri = "obo:DOID_0050117"
     connection = get_database_connection(create_database=True)
@@ -44,16 +43,11 @@ def import_disease_ontology(drop_previous=False, root_uri=None, http_proxy=None,
     )""")
     print("Loading disease ontology...")
     disease_ontology = rdflib.Graph()
-    if http_proxy:
-        os.environ["HTTP_PROXY"] = http_proxy
-    if https_proxy:
-        os.environ["HTTPS_PROXY"] = https_proxy
     try:
         disease_ontology.parse(DISEASE_ONTOLOGY_URL, format="xml")
     except URLError as e:
         print(e)
-        print('You might be operating behind a proxy. Try repeating the import '
-              'using the --http_proxy and --https_proxy flag')
+        print("You might be operating behind a proxy. Try adopting your proxy settings.")
         return
 
     # Store disease ontology version
@@ -170,15 +164,6 @@ if __name__ == '__main__':
     parser.add_argument(
         "--drop-previous", dest='drop_previous', action='store_true')
     parser.add_argument("--root-uri", default=None)
-    parser.add_argument("--http_proxy",
-                        dest="http_proxy")
-    parser.add_argument("--https_proxy",
-                        dest="https_proxy")
     parser.set_defaults(drop_previous=False)
-    parser.set_defaults(http_proxy=None)
-    parser.set_defaults(https_proxy=None)
     args = parser.parse_args()
-    import_disease_ontology(drop_previous=args.drop_previous,
-                            root_uri=args.root_uri,
-                            http_proxy=args.http_proxy,
-                            https_proxy=args.https_proxy)
+    import_disease_ontology(args.drop_previous, args.root_uri)

--- a/epitator/importers/import_geonames.py
+++ b/epitator/importers/import_geonames.py
@@ -10,8 +10,8 @@ from six import BytesIO
 from zipfile import ZipFile
 from six.moves.urllib import request
 from six.moves.urllib.error import URLError
-from epitator.get_database_connection import get_database_connection
-from epitator.utils import parse_number, batched, normalize_text
+from ..get_database_connection import get_database_connection
+from ..utils import parse_number, batched, normalize_text
 
 
 GEONAMES_ZIP_URL = "http://download.geonames.org/export/dump/allCountries.zip"

--- a/epitator/importers/import_geonames.py
+++ b/epitator/importers/import_geonames.py
@@ -5,11 +5,13 @@ import csv
 import unicodecsv
 import re
 import sys
+import os
 from six import BytesIO
 from zipfile import ZipFile
 from six.moves.urllib import request
-from ..get_database_connection import get_database_connection
-from ..utils import parse_number, batched, normalize_text
+from six.moves.urllib.error import URLError
+from epitator.get_database_connection import get_database_connection
+from epitator.utils import parse_number, batched, normalize_text
 
 
 GEONAMES_ZIP_URL = "http://download.geonames.org/export/dump/allCountries.zip"
@@ -37,9 +39,19 @@ geonames_field_mappings = [
 ]
 
 
-def read_geonames_csv():
+def read_geonames_csv(http_proxy, https_proxy):
     print("Downloading geoname data from: " + GEONAMES_ZIP_URL)
-    url = request.urlopen(GEONAMES_ZIP_URL)
+    if http_proxy:
+        os.environ["HTTP_PROXY"] = http_proxy
+    if https_proxy:
+        os.environ["HTTPS_PROXY"] = https_proxy
+    try:
+        url = request.urlopen(GEONAMES_ZIP_URL)
+    except URLError as e:
+        print(e)
+        print('You might be operating behind a proxy. Try repeating the import '
+              'using the --http_proxy and --https_proxy flag')
+        return
     zipfile = ZipFile(BytesIO(url.read()))
     print("Download complete")
     # Loading geonames data may cause errors without this line:
@@ -62,7 +74,7 @@ def read_geonames_csv():
             yield d
 
 
-def import_geonames(drop_previous=False):
+def import_geonames(drop_previous=False, http_proxy=None, https_proxy=None):
     connection = get_database_connection(create_database=True)
     cur = connection.cursor()
     if drop_previous:
@@ -93,7 +105,7 @@ def import_geonames(drop_previous=False):
         '?' for x, sqltype in geonames_field_mappings if sqltype]) + ')'
     alternatenames_insert_command = 'INSERT INTO alternatenames VALUES (?, ?, ?)'
     adminnames_insert_command = 'INSERT OR IGNORE INTO adminnames VALUES (?, ?, ?, ?, ?)'
-    for batch in batched(read_geonames_csv()):
+    for batch in batched(read_geonames_csv(http_proxy, https_proxy)):
         geoname_tuples = []
         alternatename_tuples = []
         adminname_tuples = []
@@ -148,6 +160,14 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--drop-previous", dest='drop_previous', action='store_true')
+    parser.add_argument("--http_proxy",
+                        dest="http_proxy")
+    parser.add_argument("--https_proxy",
+                        dest="https_proxy")
     parser.set_defaults(drop_previous=False)
+    parser.set_defaults(http_proxy=None)
+    parser.set_defaults(https_proxy=None)
     args = parser.parse_args()
-    import_geonames(args.drop_previous)
+    import_geonames(drop_previous=args.drop_previous,
+                    http_proxy=args.http_proxy,
+                    https_proxy=args.https_proxy)

--- a/epitator/importers/import_species.py
+++ b/epitator/importers/import_species.py
@@ -9,8 +9,10 @@ import sqlite3
 from six import BytesIO
 from zipfile import ZipFile
 from six.moves.urllib import request
+from six.moves.urllib_error import URLError
 from tempfile import NamedTemporaryFile
 import os
+import sys
 from ..get_database_connection import get_database_connection
 from ..utils import batched
 
@@ -20,9 +22,18 @@ ITIS_URL = "https://www.itis.gov/downloads/itisSqlite.zip"
 
 # The data model for the itis database is available here:
 # https://www.itis.gov/pdf/ITIS_ConceptualModelEntityDefinition.pdf
-def download_itis_database():
+def download_itis_database(http_proxy, https_proxy):
     print("Downloading ITIS data from: " + ITIS_URL)
-    url = request.urlopen(ITIS_URL)
+    if http_proxy:
+        os.environ["HTTP_PROXY"] = http_proxy
+    if https_proxy:
+        os.environ["HTTPS_PROXY"] = https_proxy
+    try:
+        url = request.urlopen(ITIS_URL)
+    except URLError:
+        print('You might be operating behind a proxy. Try repeating the import '
+              'using the --http_proxy and --https_proxy flag')
+        sys.exit(1)
     zipfile = ZipFile(BytesIO(url.read(int(url.headers['content-length']))))
     print("Download complete")
     named_temp_file = NamedTemporaryFile()
@@ -38,7 +49,7 @@ def download_itis_database():
     return named_temp_file, itis_version
 
 
-def import_species(drop_previous=False):
+def import_species(drop_previous=False, http_proxy=None, https_proxy=None):
     connection = get_database_connection(create_database=True)
     cur = connection.cursor()
     if drop_previous:
@@ -57,7 +68,7 @@ def import_species(drop_previous=False):
         itis_db_file = open(os.environ.get('ITIS_DB_PATH'))
         itis_version = os.environ.get('ITIS_VERSION')
     else:
-        itis_db_file, itis_version = download_itis_database()
+        itis_db_file, itis_version = download_itis_database(http_proxy, https_proxy)
     itis_db = sqlite3.connect(itis_db_file.name)
     cur.execute("INSERT INTO metadata VALUES ('itis_version', ?)", (itis_version,))
     itis_cur = itis_db.cursor()
@@ -149,6 +160,14 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--drop-previous", dest='drop_previous', action='store_true')
+    parser.add_argument("--http_proxy",
+                        dest="http_proxy")
+    parser.add_argument("--https_proxy",
+                        dest="https_proxy")
     parser.set_defaults(drop_previous=False)
+    parser.set_defaults(http_proxy=None)
+    parser.set_defaults(https_proxy=None)
     args = parser.parse_args()
-    import_species(args.drop_previous)
+    import_species(drop_previous=args.drop_previous,
+                   http_proxy=args.http_proxy,
+                   https_proxy=args.https_proxy)

--- a/epitator/importers/import_wikidata.py
+++ b/epitator/importers/import_wikidata.py
@@ -11,10 +11,9 @@ from six.moves.urllib.parse import urlencode
 from six.moves.urllib.error import URLError
 import json
 import datetime
-import os
 
 
-def import_wikidata(drop_previous=False, http_proxy=None, https_proxy=None):
+def import_wikidata(drop_previous=False):
     connection = get_database_connection(create_database=True)
     cur = connection.cursor()
     if drop_previous:
@@ -33,10 +32,6 @@ def import_wikidata(drop_previous=False, http_proxy=None, https_proxy=None):
         return
     cur.execute("INSERT INTO metadata VALUES ('wikidata_retrieval_date', ?)",
                 (datetime.date.today().isoformat(),))
-    if http_proxy:
-        os.environ["HTTP_PROXY"] = http_proxy
-    if https_proxy:
-        os.environ["HTTPS_PROXY"] = https_proxy
     try:
         response = urlopen("https://query.wikidata.org/sparql", str.encode(urlencode({
             "format": "json",
@@ -49,8 +44,7 @@ def import_wikidata(drop_previous=False, http_proxy=None, https_proxy=None):
         })))
     except URLError as e:
         print(e)
-        print('You might be operating behind a proxy. Try repeating the import '
-              'using the --http_proxy and --https_proxy flag')
+        print("You might be operating behind a proxy. Try adopting your proxy settings.")
         return
     results = json.loads(response.read())['results']['bindings']
     print("Importing synonyms...")
@@ -85,14 +79,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--drop-previous", dest='drop_previous', action='store_true')
-    parser.add_argument("--http_proxy",
-                        dest="http_proxy")
-    parser.add_argument("--https_proxy",
-                        dest="https_proxy")
     parser.set_defaults(drop_previous=False)
-    parser.set_defaults(http_proxy=None)
-    parser.set_defaults(https_proxy=None)
     args = parser.parse_args()
-    import_wikidata(drop_previous=args.drop_previous,
-                    http_proxy=args.http_proxy,
-                    https_proxy=args.https_proxy)
+    import_wikidata(args.drop_previous)

--- a/epitator/importers/import_wikidata.py
+++ b/epitator/importers/import_wikidata.py
@@ -5,7 +5,7 @@ Currently only animal diseases and hand selected human diseases are imported.
 """
 from __future__ import absolute_import
 from __future__ import print_function
-from epitator.get_database_connection import get_database_connection
+from ..get_database_connection import get_database_connection
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.parse import urlencode
 from six.moves.urllib.error import URLError

--- a/epitator/importers/import_wikidata.py
+++ b/epitator/importers/import_wikidata.py
@@ -13,6 +13,7 @@ import json
 import datetime
 import os
 
+
 def import_wikidata(drop_previous=False, http_proxy=None, https_proxy=None):
     connection = get_database_connection(create_database=True)
     cur = connection.cursor()


### PR DESCRIPTION
In the case of working behind a firewall, the current importers throw "ConnectionRefusedError: [WinError 10061] No connection could be made because the target machine actively refused it". If it is also not possible to create a global proxy, setting a proxy for the importers becomes necessary.