### PR TITLE
Fix wrong data type of Windows field_size_limit

### DIFF
--- a/epitator/importers/import_geonames.py
+++ b/epitator/importers/import_geonames.py
@@ -49,7 +49,7 @@ def read_geonames_csv():
     print("Download complete")
     # Loading geonames data may cause errors without setting csv.field_size_limit:
     if sys.platform == "win32":
-        max_c_long_on_windows = (2**32 / 2) - 1
+        max_c_long_on_windows = int((2**32 / 2) - 1)
         csv.field_size_limit(max_c_long_on_windows)
     else:
         csv.field_size_limit(sys.maxint if six.PY2 else six.MAXSIZE)


### PR DESCRIPTION
```max_c_long_on_windows = (2**32 / 2) - 1``` produces a float which causes a ```TypeError``` in the line below ```csv.field_size_limit(max_c_long_on_windows)```.

This pull requests fixes the error by casting the value to an int beforehand.